### PR TITLE
fix: correct directory name for exercise 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 exercise_1_etl_pipeline/dagster_home/
-exercise_3_etl_pipeline/.venv/
+exercise_3_system_design/.venv/
 __pycache__/
 *.pyc
 *.pyo


### PR DESCRIPTION
fix: correct directory name for exercise 3 virtual environment in .gitignore